### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": { "node": ">=0.10.0" },
   "preferGlobal": true,
   "bin": {
-    "benchd": "./bin/benchd",
+    "benchd": "./bin/benchd"
   },
   "dependencies": {
     "ejs": "^2.3.3",
@@ -19,6 +19,6 @@
     "start": "node lib/server.js"
   },
   "keywords": [ "benchmark", "benchmarking" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/benchd/raw/master/LICENSE" } ],
+  "license": "MIT",
   "repository": { "type": "git", "url": "http://github.com/mscdex/benchd.git" }
 }


### PR DESCRIPTION
Fix a syntax error and change the license field (licenses is deprecated: https://docs.npmjs.com/files/package.json#license)
